### PR TITLE
Fix #77728: pgort140.DLL missing

### DIFF
--- a/script/snap.php
+++ b/script/snap.php
@@ -143,26 +143,15 @@ if ($branch->hasNewRevision() || !$branch->isLastRevisionExported($branch->getLa
 			}
 			$build->make();
 			/* $html_make_log = $build->getMakeLogParsed(); */
-		} catch (Exception $e) {
-			echo $e->getMessage() . "\n";
-			echo $build->log_buildconf;
-		}
-		if ($branch->config->getPGO() == 1)  {
-			echo "Creating PGO build\n";
-			try {
+			if ($branch->config->getPGO() == 1)  {
+				echo "Creating PGO build\n";
 				$build->pgoTrain();
 				$build->make(' clean-pgo');
 				$build->configure(' "--with-pgo" ', false);
 				$build->make();
 				$html_make_log = $build->getMakeLogParsed();
 				$need_pgo_build = false;
-			} catch (Exception $e) {
-				echo $e->getMessage() . "\n";
-				echo $build->log_buildconf;
 			}
-		}
-
-		try {
 			$build->makeArchive();
 		} catch (Exception $e) {
 			echo $e->getMessage() . "\n";

--- a/script/snap.php
+++ b/script/snap.php
@@ -145,7 +145,13 @@ if ($branch->hasNewRevision() || !$branch->isLastRevisionExported($branch->getLa
 			/* $html_make_log = $build->getMakeLogParsed(); */
 			if ($branch->config->getPGO() == 1)  {
 				echo "Creating PGO build\n";
-				$build->pgoTrain();
+				try {
+					// if training fails, we still can go on for snaps
+					$build->pgoTrain();
+				} catch (Exception $e) {
+					echo $e->getMessage() . "\n";
+					echo $build->log_buildconf;
+				}
 				$build->make(' clean-pgo');
 				$build->configure(' "--with-pgo" ', false);
 				$build->make();


### PR DESCRIPTION
If a PGO build is requested, but a build error occurs after the PGI
build has succeeded and before the PGO build has even been attempted
(for instance, if the PGO training fails), we may get a bogus archive
containing the PGI build, without any hint.  We apply a quick fix which
requires to run the PGO build if requested, and reports a respective
error otherwise.