### PR TITLE
Disable ext/interbase

### DIFF
--- a/data/config/branch/x64/phpmaster.ini
+++ b/data/config/branch/x64/phpmaster.ini
@@ -15,20 +15,20 @@ arch=x64
 name=nts-windows-vc15-x64
 compiler=vc15
 arch=x64
-configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --with-oci8-12c=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --enable-com-dotnet=shared --without-analyzer
+configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --with-oci8-12c=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --enable-com-dotnet=shared --without-interbase --without-analyzer
 platform=windows
 
 [build-ts-windows-vc15-x64]
 name=ts-windows-vc15-x64
 compiler=vc15
 arch=x64
-configure_options=--enable-snapshot-build --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --with-oci8-12c=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --enable-com-dotnet=shared --without-analyzer
+configure_options=--enable-snapshot-build --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --with-oci8-12c=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --enable-com-dotnet=shared --without-interbase --without-analyzer
 platform=windows
 
 [build-nts-windows-vc15-x64-avx]
 name=nts-windows-vc15-x64
 compiler=vc15
 arch=x64
-configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --with-oci8-12c=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --enable-com-dotnet=shared --without-analyzer --enable-native-intrinsics=avx
+configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --with-oci8-12c=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --enable-com-dotnet=shared --without-interbase --without-analyzer --enable-native-intrinsics=avx
 platform=windows
 

--- a/data/config/branch/x86/phpmaster.ini
+++ b/data/config/branch/x86/phpmaster.ini
@@ -15,12 +15,12 @@ arch=x86
 name=nts-windows-vc15-x86
 compiler=vc15
 arch=x86
-configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:\php-snap-build\deps_aux\oracle\x86\instantclient_12_1\sdk,shared --with-oci8-12c=c:\php-snap-build\deps_aux\oracle\x86\instantclient_12_1\sdk,shared --enable-com-dotnet=shared --without-analyzer
+configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:\php-snap-build\deps_aux\oracle\x86\instantclient_12_1\sdk,shared --with-oci8-12c=c:\php-snap-build\deps_aux\oracle\x86\instantclient_12_1\sdk,shared --enable-com-dotnet=shared --without-interbase --without-analyzer
 platform=windows
 
 [build-ts-windows-vc15-x86]
 name=ts-windows-vc15-x86
 compiler=vc15
 arch=x86
-configure_options=--enable-snapshot-build --enable-debug-pack --with-pdo-oci=c:\php-snap-build\deps_aux\oracle\x86\instantclient_12_1\sdk,shared --with-oci8-12c=c:\php-snap-build\deps_aux\oracle\x86\instantclient_12_1\sdk,shared --enable-com-dotnet=shared --without-analyzer
+configure_options=--enable-snapshot-build --enable-debug-pack --with-pdo-oci=c:\php-snap-build\deps_aux\oracle\x86\instantclient_12_1\sdk,shared --with-oci8-12c=c:\php-snap-build\deps_aux\oracle\x86\instantclient_12_1\sdk,shared --enable-com-dotnet=shared --without-interbase --without-analyzer
 platform=windows


### PR DESCRIPTION
Commit bd73607 of php-src[1] broke the ext/ibase build; following Joe's
reasoning[2] we disable the ext/interbase builds (at least for now).

[1] <http://git.php.net/?p=php-src.git;a=commit;h=bd73607b9e4811e7caa9d2ff4d227626ffd35dab>
[2] <https://github.com/php/php-src/pull/3976#issue-263815945>