### PR TITLE
Rename VC to VS

### DIFF
--- a/include/BuildVC.php
+++ b/include/BuildVC.php
@@ -48,9 +48,9 @@ class BuildVC {
 			throw new \Exception("Arch mismatch. PHP SDK is configured for '$sdk_arch', while the current RMTOOLS config targets '{$this->architecture}'");
 		}
 
-		$sdk_vc = getenv("PHP_SDK_VC");
-		if (strtolower($this->compiler) != strtolower($sdk_vc)) {
-			throw new \Exception("Compiler mismatch. PHP SDK is configured for '$sdk_vc', while the current RMTOOLS config targets '{$this->compiler}'");
+		$sdk_vs = getenv("PHP_SDK_VS");
+		if (strtolower($this->compiler) != strtolower($sdk_vs)) {
+			throw new \Exception("Compiler mismatch. PHP SDK is configured for '$sdk_vs', while the current RMTOOLS config targets '{$this->compiler}'");
 		}
 
 		$env = getenv();

--- a/include/PeclBranch.php
+++ b/include/PeclBranch.php
@@ -94,6 +94,7 @@ class PeclBranch {
 
 		$compiler	= strtolower($build_config['compiler']);
 		switch ($compiler) {
+			case 'vs16':
 			case 'vc15':
 			case 'vc14':
 			case 'vc12':

--- a/include/PeclBuildVC.php
+++ b/include/PeclBuildVC.php
@@ -48,9 +48,9 @@ class PeclBuildVC {
 			throw new \Exception("Arch mismatch. PHP SDK is configured for '$sdk_arch', while the current RMTOOLS config targets '{$this->architecture}'");
 		}
 
-		$sdk_vc = getenv("PHP_SDK_VC");
-		if (strtolower($this->compiler) != strtolower($sdk_vc)) {
-			throw new \Exception("Compiler mismatch. PHP SDK is configured for '$sdk_vc', while the current RMTOOLS config targets '{$this->compiler}'");
+		$sdk_vs = getenv("PHP_SDK_VS");
+		if (strtolower($this->compiler) != strtolower($sdk_vs)) {
+			throw new \Exception("Compiler mismatch. PHP SDK is configured for '$sdk_vs', while the current RMTOOLS config targets '{$this->compiler}'");
 		}
 
 		$env = getenv();


### PR DESCRIPTION
We're skipping the Pickle stuff for now, since it's not even up-to-date
for VC15.  We also keep the VC prefix for some classes, such as
`BuildVC`.