### PR TITLE
Attempt to fix runkit7 PECL builds on Windows

### DIFF
--- a/data/config/pecl/exts.ini
+++ b/data/config/pecl/exts.ini
@@ -699,5 +699,5 @@ type=enable
 
 [runkit7]
 type=enable
-opts[]=--enable-runkit
+opts[]=--enable-runkit=shared
 no_conf=1


### PR DESCRIPTION
See https://marc.info/?l=pecl-dev&m=155562978906879&w=2

`--enable-extname` will attempt to build that extension as a static
extension, which won't produce a dll that can be used on windows.php.net

cc @cmb69 