### PR TITLE
Increase length of short ref

### DIFF
--- a/include/Branch.php
+++ b/include/Branch.php
@@ -227,7 +227,7 @@ class Branch {
 	{
 		$rev_name = $revision ? $revision : $this->data->revision_last;
 		if (strlen($rev_name) == 40) {
-			$rev_name = substr($rev_name, 0, 7);
+			$rev_name = substr($rev_name, 0, 10);
 		}
 		$dir_name = $this->config->getName() . '-src-' . ($build_type ? $build_type.'-' : $build_type) . 'r' . $rev_name;
 		$build_dir = $this->config->getBuildDir();

--- a/script/snap.php
+++ b/script/snap.php
@@ -73,7 +73,7 @@ if ($branch->hasNewRevision() || !$branch->isLastRevisionExported($branch->getLa
 	}
 
 	if (strlen($last_rev) == 40) {
-		$last_rev = substr($last_rev, 0, 7);
+		$last_rev = substr($last_rev, 0, 10);
 	}
 	$src_original_path =  $branch->createSourceSnap($build_type, $last_rev);
 


### PR DESCRIPTION
Latest commit on `master` branch of `php-src` is inaccessible using short commit hash of 7 characters, so the zip file fails to download.
For hash `6768f4705cf0603d4770e3825795ec6b30bbb8c1`, these URLs would `404`.
```
https://github.com/php/php-src/commit/6768f47
https://codeload.github.com/php/php-src/zip/6768f47
```
This results in this [error](https://github.com/shivammathur/php-builder-windows/runs/1366632460?check_suite_focus=true#step:9:20), as the zip fails to download

```
Fatal error: Uncaught Exception: Failed to rename 'C:/php-snap-build/obj-x64\ts-windows-vs16-x64-6768f47-tmp-unzip/php-src-6768f47' to 'C:/php-snap-build/obj-x64/master-src-ts-windows-vs16-x64-r6768f47' in C:\php-snap-build\rmtools\include\Branch.php:276
```

Increasing the length to 10 characters would be a good fix as `git log --oneline` currently on `php-src` uses 10 characters for shortening commit hashes.

```
$ git log --oneline
6768f4705c (HEAD -> master, up/master, 6768f47) Merge branch 'PHP-8.0'
49ca191667 (up/PHP-8.0, PHP-8.0) Merge branch 'PHP-7.4' into PHP-8.0
77b6e95d92 (up/PHP-7.4) Split tests for compatibility with ICU 68.1
...
...
```

**Relevant discussion:** https://stackoverflow.com/questions/18134627 