### PR TITLE
Update instantclient to 19_9 for snaps

### DIFF
--- a/data/config/branch/x64/php80.ini
+++ b/data/config/branch/x64/php80.ini
@@ -15,20 +15,20 @@ arch=x64
 name=nts-windows-vs16-x64
 compiler=vs16
 arch=x64
-configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --with-oci8-12c=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --enable-com-dotnet=shared --without-analyzer
+configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_19_9/sdk,shared --with-oci8-19=c:/php-snap-build/deps_aux/oracle/x64/instantclient_19_9/sdk,shared --enable-com-dotnet=shared --without-analyzer
 platform=windows
 
 [build-ts-windows-vs16-x64]
 name=ts-windows-vs16-x64
 compiler=vs16
 arch=x64
-configure_options=--enable-snapshot-build --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --with-oci8-12c=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --enable-com-dotnet=shared --without-analyzer
+configure_options=--enable-snapshot-build --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_19_9/sdk,shared --with-oci8-19=c:/php-snap-build/deps_aux/oracle/x64/instantclient_19_9/sdk,shared --enable-com-dotnet=shared --without-analyzer
 platform=windows
 
 [build-nts-windows-vs16-x64-avx]
 name=nts-windows-vs16-x64
 compiler=vs16
 arch=x64
-configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --with-oci8-12c=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --enable-com-dotnet=shared --without-analyzer --enable-native-intrinsics=avx
+configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_19_9/sdk,shared --with-oci8-19=c:/php-snap-build/deps_aux/oracle/x64/instantclient_19_9/sdk,shared --enable-com-dotnet=shared --without-analyzer --enable-native-intrinsics=avx
 platform=windows
 

--- a/data/config/branch/x64/php81.ini
+++ b/data/config/branch/x64/php81.ini
@@ -15,19 +15,19 @@ arch=x64
 name=nts-windows-vs16-x64
 compiler=vs16
 arch=x64
-configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --with-oci8-12c=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --enable-com-dotnet=shared --without-analyzer
+configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_19_9/sdk,shared --with-oci8-19=c:/php-snap-build/deps_aux/oracle/x64/instantclient_19_9/sdk,shared --enable-com-dotnet=shared --without-analyzer
 platform=windows
 
 [build-ts-windows-vs16-x64]
 name=ts-windows-vs16-x64
 compiler=vs16
 arch=x64
-configure_options=--enable-snapshot-build --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --with-oci8-12c=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --enable-com-dotnet=shared --without-analyzer
+configure_options=--enable-snapshot-build --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_19_9/sdk,shared --with-oci8-19=c:/php-snap-build/deps_aux/oracle/x64/instantclient_19_9/sdk,shared --enable-com-dotnet=shared --without-analyzer
 platform=windows
 
 [build-nts-windows-vs16-x64-avx]
 name=nts-windows-vs16-x64
 compiler=vs16
 arch=x64
-configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --with-oci8-12c=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --enable-com-dotnet=shared --without-analyzer --enable-native-intrinsics=avx
+configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_19_9/sdk,shared --with-oci8-19=c:/php-snap-build/deps_aux/oracle/x64/instantclient_19_9/sdk,shared --enable-com-dotnet=shared --without-analyzer --enable-native-intrinsics=avx
 platform=windows

--- a/data/config/branch/x64/phpmaster.ini
+++ b/data/config/branch/x64/phpmaster.ini
@@ -15,20 +15,20 @@ arch=x64
 name=nts-windows-vs16-x64
 compiler=vs16
 arch=x64
-configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --with-oci8-12c=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --enable-com-dotnet=shared --without-analyzer
+configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_19_9/sdk,shared --with-oci8-19=c:/php-snap-build/deps_aux/oracle/x64/instantclient_19_9/sdk,shared --enable-com-dotnet=shared --without-analyzer
 platform=windows
 
 [build-ts-windows-vs16-x64]
 name=ts-windows-vs16-x64
 compiler=vs16
 arch=x64
-configure_options=--enable-snapshot-build --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --with-oci8-12c=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --enable-com-dotnet=shared --without-analyzer
+configure_options=--enable-snapshot-build --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_19_9/sdk,shared --with-oci8-19=c:/php-snap-build/deps_aux/oracle/x64/instantclient_19_9/sdk,shared --enable-com-dotnet=shared --without-analyzer
 platform=windows
 
 [build-nts-windows-vs16-x64-avx]
 name=nts-windows-vs16-x64
 compiler=vs16
 arch=x64
-configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --with-oci8-12c=c:/php-snap-build/deps_aux/oracle/x64/instantclient_12_1/sdk,shared --enable-com-dotnet=shared --without-analyzer --enable-native-intrinsics=avx
+configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:/php-snap-build/deps_aux/oracle/x64/instantclient_19_9/sdk,shared --with-oci8-19=c:/php-snap-build/deps_aux/oracle/x64/instantclient_19_9/sdk,shared --enable-com-dotnet=shared --without-analyzer --enable-native-intrinsics=avx
 platform=windows
 

--- a/data/config/branch/x86/php80.ini
+++ b/data/config/branch/x86/php80.ini
@@ -15,12 +15,12 @@ arch=x86
 name=nts-windows-vs16-x86
 compiler=vs16
 arch=x86
-configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:\php-snap-build\deps_aux\oracle\x86\instantclient_12_1\sdk,shared --with-oci8-12c=c:\php-snap-build\deps_aux\oracle\x86\instantclient_12_1\sdk,shared --enable-com-dotnet=shared --without-analyzer
+configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:\php-snap-build\deps_aux\oracle\x86\instantclient_19_9\sdk,shared --with-oci8-19=c:\php-snap-build\deps_aux\oracle\x86\instantclient_19_9\sdk,shared --enable-com-dotnet=shared --without-analyzer
 platform=windows
 
 [build-ts-windows-vs16-x86]
 name=ts-windows-vs16-x86
 compiler=vs16
 arch=x86
-configure_options=--enable-snapshot-build --enable-debug-pack --with-pdo-oci=c:\php-snap-build\deps_aux\oracle\x86\instantclient_12_1\sdk,shared --with-oci8-12c=c:\php-snap-build\deps_aux\oracle\x86\instantclient_12_1\sdk,shared --enable-com-dotnet=shared --without-analyzer
+configure_options=--enable-snapshot-build --enable-debug-pack --with-pdo-oci=c:\php-snap-build\deps_aux\oracle\x86\instantclient_19_9\sdk,shared --with-oci8-19=c:\php-snap-build\deps_aux\oracle\x86\instantclient_19_9\sdk,shared --enable-com-dotnet=shared --without-analyzer
 platform=windows

--- a/data/config/branch/x86/php81.ini
+++ b/data/config/branch/x86/php81.ini
@@ -15,12 +15,12 @@ arch=x86
 name=nts-windows-vs16-x86
 compiler=vs16
 arch=x86
-configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:\php-snap-build\deps_aux\oracle\x86\instantclient_12_1\sdk,shared --with-oci8-12c=c:\php-snap-build\deps_aux\oracle\x86\instantclient_12_1\sdk,shared --enable-com-dotnet=shared --without-analyzer
+configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:\php-snap-build\deps_aux\oracle\x86\instantclient_19_9\sdk,shared --with-oci8-19=c:\php-snap-build\deps_aux\oracle\x86\instantclient_19_9\sdk,shared --enable-com-dotnet=shared --without-analyzer
 platform=windows
 
 [build-ts-windows-vs16-x86]
 name=ts-windows-vs16-x86
 compiler=vs16
 arch=x86
-configure_options=--enable-snapshot-build --enable-debug-pack --with-pdo-oci=c:\php-snap-build\deps_aux\oracle\x86\instantclient_12_1\sdk,shared --with-oci8-12c=c:\php-snap-build\deps_aux\oracle\x86\instantclient_12_1\sdk,shared --enable-com-dotnet=shared --without-analyzer
+configure_options=--enable-snapshot-build --enable-debug-pack --with-pdo-oci=c:\php-snap-build\deps_aux\oracle\x86\instantclient_19_9\sdk,shared --with-oci8-19=c:\php-snap-build\deps_aux\oracle\x86\instantclient_19_9\sdk,shared --enable-com-dotnet=shared --without-analyzer
 platform=windows

--- a/data/config/branch/x86/phpmaster.ini
+++ b/data/config/branch/x86/phpmaster.ini
@@ -15,12 +15,12 @@ arch=x86
 name=nts-windows-vs16-x86
 compiler=vs16
 arch=x86
-configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:\php-snap-build\deps_aux\oracle\x86\instantclient_12_1\sdk,shared --with-oci8-12c=c:\php-snap-build\deps_aux\oracle\x86\instantclient_12_1\sdk,shared --enable-com-dotnet=shared --without-analyzer
+configure_options=--enable-snapshot-build --disable-zts --enable-debug-pack --with-pdo-oci=c:\php-snap-build\deps_aux\oracle\x86\instantclient_19_9\sdk,shared --with-oci8-19=c:\php-snap-build\deps_aux\oracle\x86\instantclient_19_9\sdk,shared --enable-com-dotnet=shared --without-analyzer
 platform=windows
 
 [build-ts-windows-vs16-x86]
 name=ts-windows-vs16-x86
 compiler=vs16
 arch=x86
-configure_options=--enable-snapshot-build --enable-debug-pack --with-pdo-oci=c:\php-snap-build\deps_aux\oracle\x86\instantclient_12_1\sdk,shared --with-oci8-12c=c:\php-snap-build\deps_aux\oracle\x86\instantclient_12_1\sdk,shared --enable-com-dotnet=shared --without-analyzer
+configure_options=--enable-snapshot-build --enable-debug-pack --with-pdo-oci=c:\php-snap-build\deps_aux\oracle\x86\instantclient_19_9\sdk,shared --with-oci8-19=c:\php-snap-build\deps_aux\oracle\x86\instantclient_19_9\sdk,shared --enable-com-dotnet=shared --without-analyzer
 platform=windows


### PR DESCRIPTION
Update `instantclient` to 19_9 for snaps to match stable builds.